### PR TITLE
join page: fixes broken slack link & typo

### DIFF
--- a/join/join.jsx
+++ b/join/join.jsx
@@ -55,11 +55,11 @@ class Join extends React.Component {
             <iframe src="./join/embed.html" style={{width:450, margin:20, height:250, overflow:'hidden'}}/>
             <div className="github-card" data-github="nlp-compromise/nlp_compromise" data-width="400" data-height="" data-theme="default"></div>
 
-            <div>Join our <a href="superscriptjs.slack.com/messages/nlp_compromise/">Slack group</a></div>
+            <div>Join our <a href="https://superscriptjs.slack.com/messages/nlp_compromise/">Slack group</a></div>
             <p/>
             <div>File an <a href="https://github.com/nlp-compromise/nlp_compromise/issues">issue on github</a></div>
             <p/>
-            <div>Browser the <a href="./browse">annotated source</a></div>
+            <div>Browse the <a href="./browse">annotated source</a></div>
           </td>
 
           {/*right side*/}


### PR DESCRIPTION
I was looking for information on the Slack group, and came across this.
BTW - does the group require an invite?

---

Without the `https://` this is treated as a relative link.
Also, `Browser` => `Browse`

<img width="518" alt="screen shot 2016-03-03 at 10 21 50 pm" src="https://cloud.githubusercontent.com/assets/6632454/13517985/c247eb3a-e18e-11e5-8579-f8bd6cc6f436.png">
