### PR TITLE
Use https for scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
     <link href="./lib/material.min.css" rel="stylesheet">
     <title>nlp compromise</title>
-    <script src="http://npmcdn.com/nlp_compromise@latest/builds/nlp_compromise.js"></script>
-    <script src="http://npmcdn.com/nlp-syllables@latest/builds/nlp-syllables.min.js"></script>
-    <script src="http://npmcdn.com/nlp-locale@latest/builds/nlp-locale.min.js"></script>
-    <script src="http://npmcdn.com/nlp-ngram@latest/builds/nlp-ngram.min.js"></script>
+    <script src="https://npmcdn.com/nlp_compromise@latest/builds/nlp_compromise.js"></script>
+    <script src="https://npmcdn.com/nlp-syllables@latest/builds/nlp-syllables.min.js"></script>
+    <script src="https://npmcdn.com/nlp-locale@latest/builds/nlp-locale.min.js"></script>
+    <script src="https://npmcdn.com/nlp-ngram@latest/builds/nlp-ngram.min.js"></script>
     <!-- Material -->
     <link rel="stylesheet" href="./lib/material.min.css">
     <link rel="stylesheet" href="./lib/icon.css">


### PR DESCRIPTION
To prevent the browser from blocking the scripts when going to https://nlp-compromise.github.io/website
