### PR TITLE
Update remote urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
     <link href="./lib/material.min.css" rel="stylesheet">
     <title>nlp compromise</title>
-    <script src="http://npmcdn.com/nlp_compromise@latest/builds/nlp_compromise.js"></script>
-    <script src="http://npmcdn.com/nlp-syllables@latest/builds/nlp-syllables.min.js"></script>
-    <script src="http://npmcdn.com/nlp-locale@latest/builds/nlp-locale.min.js"></script>
-    <script src="http://npmcdn.com/nlp-ngram@latest/builds/nlp-ngram.min.js"></script>
+    <script src="//npmcdn.com/nlp_compromise@latest/builds/nlp_compromise.js"></script>
+    <script src="//npmcdn.com/nlp-syllables@latest/builds/nlp-syllables.min.js"></script>
+    <script src="//npmcdn.com/nlp-locale@latest/builds/nlp-locale.min.js"></script>
+    <script src="//npmcdn.com/nlp-ngram@latest/builds/nlp-ngram.min.js"></script>
     <!-- Material -->
     <link rel="stylesheet" href="./lib/material.min.css">
     <link rel="stylesheet" href="./lib/icon.css">


### PR DESCRIPTION
Without the protocol portion, the current protocol will be used, which appears to work for npmcdn.com
