### PR TITLE
Use npmcdn for nlp_compromise.min.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="./lib/material.min.css" rel="stylesheet">
     <title>nlp compromise</title>
     <!-- <script src="../nlp_compromise/builds/nlp_compromise.js"></script> -->
-    <script src="//cdn.nlpcompromise.com/nlp_compromise.min.js"></script>
+    <script src="//npmcdn.com/nlp_compromise@4.10.6/builds/nlp_compromise.min.js"></script>
     <script src="//npmcdn.com/nlp-syllables@latest/builds/nlp-syllables.min.js"></script>
     <script src="//npmcdn.com/nlp-locale@latest/builds/nlp-locale.min.js"></script>
     <script src="//npmcdn.com/nlp-ngram@latest/builds/nlp-ngram.min.js"></script>


### PR DESCRIPTION
cdn.nlpcompromise.com just redirects to npmcdn, but doesn't support HTTPS, breaking loading the demo over HTTPS.
